### PR TITLE
Use HTTP status code 401 to determine login status

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -45,7 +45,7 @@ const NavBar = () => {
           <Image alt='OONI Logo' src={OONILogo} height='32px' width='115px' />
         </NextLink></NavItem>
         <Box ml='auto'>
-        {!loading && user &&
+        {!loading && user.loggedIn &&
             <Link href='#logout' color='white' onClick={onLogout}>Logout</Link>
         }
         </Box>

--- a/pages/login.js
+++ b/pages/login.js
@@ -8,7 +8,6 @@ import LoginForm from '../components/LoginForm'
 import { apiEndpoints, loginUser } from '../components/lib/api'
 import { mutate } from 'swr'
 import Loading from '../components/Loading'
-import { useUser } from '../components/lib/hooks'
 import QuickStartGuide from '../components/submit/QuickStartGuide'
 
 const Login = () => {
@@ -17,14 +16,6 @@ const Login = () => {
   const [error, setError] = useState(null)
   const router = useRouter()
   const { token, returnTo = '/' } = router.query
-
-  const { user, loading } = useUser()
-
-  useEffect(() => {
-    if (!loading && user !== null) {
-      router.replace('/')
-    }
-  }, [user, loading, router])
 
   const onLoginSubmit = useCallback(() => {
     // After submitting the login form


### PR DESCRIPTION
If the API call `/api/_/account_metadata` returns a `401` HTTP code, we use that to redirect to the `/login` page.